### PR TITLE
Upgrade to Debian Buster

### DIFF
--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
-ENV VARNISH_VERSION 6.2.0-1~stretch
+ENV VARNISH_VERSION 6.2.0-1~buster
 
 RUN set -ex; \
 	fetchDeps=" \
@@ -9,14 +9,14 @@ RUN set -ex; \
 		gnupg \
 	"; \
 	apt-get update; \
-	apt-get install -y --no-install-recommends apt-transport-https $fetchDeps; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
 	key=B54813B54CA95257D3590B3F1B0096460868C7A9; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver http://ha.pool.sks-keyservers.net/ --recv-keys $key; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys $key; \
 	gpg --batch --export export $key > /etc/apt/trusted.gpg.d/varnish.gpg; \
 	gpgconf --kill all; \
 	rm -rf $GNUPGHOME; \
-	echo deb https://packagecloud.io/varnishcache/varnish62/debian/ stretch main > /etc/apt/sources.list.d/varnish.list; \
+	echo deb https://packagecloud.io/varnishcache/varnish62/debian/ buster main > /etc/apt/sources.list.d/varnish.list; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends varnish=$VARNISH_VERSION; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \

--- a/populate.sh
+++ b/populate.sh
@@ -4,8 +4,8 @@ set -e
 declare -A IMAGES
 declare -A KEYS
 
-IMAGES[6.2]="fresh/debian	62	6.2.0-1~stretch	6.2.0-1 6.2.0 6 latest fresh"
-IMAGES[6.0]="stable/debian	60lts	6.0.3-1~stretch	6.0.3-1 6.0.3 stable"
+IMAGES[6.2]="fresh/debian	62	6.2.0-1~buster	6.2.0-1 6.2.0 6 latest fresh"
+IMAGES[6.0]="stable/debian	60lts	6.0.3-1~buster	6.0.3-1 6.0.3 stable"
 
 KEYS[6.2]=B54813B54CA95257D3590B3F1B0096460868C7A9
 KEYS[6.0]=48D81A24CB0456F5D59431D94CFCFD6BA750EDCD
@@ -23,7 +23,7 @@ update_dockerfiles() {
 	curl -fL https://packagecloud.io/varnishcache/varnish$repo/gpgkey -o $workdir/gpgkey
 
 	cat > $workdir/Dockerfile << EOF
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 ENV VARNISH_VERSION $package
 
@@ -34,14 +34,14 @@ RUN set -ex; \\
 		gnupg \\
 	"; \\
 	apt-get update; \\
-	apt-get install -y --no-install-recommends apt-transport-https \$fetchDeps; \\
+	apt-get install -y --no-install-recommends \$fetchDeps; \\
 	key=$key; \\
 	export GNUPGHOME="\$(mktemp -d)"; \\
-	gpg --batch --keyserver http://ha.pool.sks-keyservers.net/ --recv-keys \$key; \\
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys \$key; \\
 	gpg --batch --export export \$key > /etc/apt/trusted.gpg.d/varnish.gpg; \\
 	gpgconf --kill all; \\
 	rm -rf \$GNUPGHOME; \\
-	echo deb https://packagecloud.io/varnishcache/varnish$repo/debian/ stretch main > /etc/apt/sources.list.d/varnish.list; \\
+	echo deb https://packagecloud.io/varnishcache/varnish$repo/debian/ buster main > /etc/apt/sources.list.d/varnish.list; \\
 	apt-get update; \\
 	apt-get install -y --no-install-recommends varnish=\$VARNISH_VERSION; \\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \$fetchDeps; \\

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
-ENV VARNISH_VERSION 6.0.3-1~stretch
+ENV VARNISH_VERSION 6.0.3-1~buster
 
 RUN set -ex; \
 	fetchDeps=" \
@@ -9,14 +9,14 @@ RUN set -ex; \
 		gnupg \
 	"; \
 	apt-get update; \
-	apt-get install -y --no-install-recommends apt-transport-https $fetchDeps; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
 	key=48D81A24CB0456F5D59431D94CFCFD6BA750EDCD; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --batch --keyserver http://ha.pool.sks-keyservers.net/ --recv-keys $key; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys $key; \
 	gpg --batch --export export $key > /etc/apt/trusted.gpg.d/varnish.gpg; \
 	gpgconf --kill all; \
 	rm -rf $GNUPGHOME; \
-	echo deb https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main > /etc/apt/sources.list.d/varnish.list; \
+	echo deb https://packagecloud.io/varnishcache/varnish60lts/debian/ buster main > /etc/apt/sources.list.d/varnish.list; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends varnish=$VARNISH_VERSION; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $fetchDeps; \


### PR DESCRIPTION
So far there are no packages for Buster, but this will hopefully be fixed very soon.

I've issues when forcing `http` on `--keyserver`, so I removed this. 