### PR TITLE
Update to fix VSV00004

### DIFF
--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
 
-ENV VARNISH_VERSION 6.3.0-1~stretch
+ENV VARNISH_VERSION 6.3.1-1~stretch
 
 RUN set -ex; \
 	fetchDeps=" \

--- a/populate.sh
+++ b/populate.sh
@@ -4,8 +4,8 @@ set -e
 declare -A IMAGES
 declare -A KEYS
 
-IMAGES[6.3]="fresh/debian	63	6.3.0-1~stretch	6.3.0-1 6.3.0 6 latest fresh"
-IMAGES[6.0]="stable/debian	60lts	6.0.4-1~stretch	6.0.4-1 6.0.4 stable"
+IMAGES[6.3]="fresh/debian	63	6.3.1-1~stretch	6.3.1-1 6.3.1 6 latest fresh"
+IMAGES[6.0]="stable/debian	60lts	6.0.5-1~stretch	6.0.5-1 6.0.5 stable"
 
 KEYS[6.3]=920A8A7AA7120A8604BCCD294A42CD6EB810E55D
 KEYS[6.0]=48D81A24CB0456F5D59431D94CFCFD6BA750EDCD

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
 
-ENV VARNISH_VERSION 6.0.4-1~stretch
+ENV VARNISH_VERSION 6.0.5-1~stretch
 
 RUN set -ex; \
 	fetchDeps=" \


### PR DESCRIPTION
This updates to the 6.0.5 and 6.3.1 versions of Varnish (released 2019-10-21), addressing the VSV00004 workspace information leak.

More info here: https://varnish-cache.org/security/VSV00004.html