### PR TITLE
PROXY protocol support + memory storage sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,17 @@ When running the Varnish image, a `varnishd` process will be started that listen
 * port `80` for *plain HTTP*
 * port `8443` for the *PROXY protocol*
 
-If the Varnish container sits behind a loadbalancer or proxy server that speaks the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt), you can connect to Varnish on port `8843`. Under all other circumstances, a connection must be made on port `80`.
+> See [TLS section](#tls) for more information about the primary *PROXY protocol* use case.
 
 Varnish will run with a default memory storage size of `100M`. The `SIZE` *environment variable* can be used to extend the size.
 
 # TLS
 
-If you want to connect to Varnish via *HTTPS*, you'll need to terminate the *TLS* connection elsewhere. *TLS termination* can be done on some loadbalancers, but the Varnish ecosystem also provides *a purpose-built TLS terminator* called [Hitch](https://hitch-tls.org/). 
+If you want to connect to Varnish via *HTTPS*, you'll need to terminate the *TLS* connection elsewhere. *TLS termination* can be done on some loadbalancers or proxy servers, but the Varnish ecosystem also provides *a purpose-built TLS terminator* called [Hitch](https://hitch-tls.org/). 
 
-Hitch supports the *PROXY protocol* and is transparent to Varnish. The *PROXY protocol* has the ability to keep track of *the original client IP address*. Varnish also supports this, and will automatically take this IP address and assign it to the `X-Forwarded-For` request header.
+Hitch supports the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) and is transparent to Varnish. The *PROXY protocol* has the ability to keep track of *the original client IP address*.
+
+> Hitch, or any other TLS terminator that supports the *PROXY protocol* will connect to Varnish on port `8443`.
 
 # Image documentation
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ To generate the file that will become https://github.com/docker-library/official
 # commit your changes first!
 ./populate.sh library
 ```
+# Running
+
+When running the Varnish image, a `varnishd` process will be started that listens on the following ports:
+
+* port `80` for *plain HTTP*
+* port `8443` for the *PROXY protocol*
+
+If the Varnish container sits behind a loadbalancer or proxy server that speaks the [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt), you can connect to Varnish on port `8843`. Under all other circumstances, a connection must be made on port `80`.
+
+Varnish will run with a default memory storage size of `100M`. The `SIZE` *environment variable* can be used to extend the size.
 
 # Image documentation
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Varnish will run with a default memory storage size of `100M`. The `SIZE` *envir
 
 # TLS
 
-If you want to connect to Varnish via *HTTPS*, you'll need to terminate the *TLS* connection elsewhere. *TLS termination* can be done on some loadbalancers, but the Varnish ecosystem also provides *a purpous-built TLS terminator* called [Hitch](https://hitch-tls.org/). 
+If you want to connect to Varnish via *HTTPS*, you'll need to terminate the *TLS* connection elsewhere. *TLS termination* can be done on some loadbalancers, but the Varnish ecosystem also provides *a purpose-built TLS terminator* called [Hitch](https://hitch-tls.org/). 
 
 Hitch supports the *PROXY protocol* and is transparent to Varnish. The *PROXY protocol* has the ability to keep track of *the original client IP address*. Varnish also supports this, and will automatically take this IP address and assign it to the `X-Forwarded-For` request header.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ If the Varnish container sits behind a loadbalancer or proxy server that speaks 
 
 Varnish will run with a default memory storage size of `100M`. The `SIZE` *environment variable* can be used to extend the size.
 
+# TLS
+
+If you want to connect to Varnish via *HTTPS*, you'll need to terminate the *TLS* connection elsewhere. *TLS termination* can be done on some loadbalancers, but the Varnish ecosystem also provides *a purpous-built TLS terminator* called [Hitch](https://hitch-tls.org/). 
+
+Hitch supports the *PROXY protocol* and is transparent to Varnish. The *PROXY protocol* has the ability to keep track of *the original client IP address*. Varnish also supports this, and will automatically take this IP address and assign it to the `X-Forwarded-For` request header.
+
 # Image documentation
 
 Please see https://github.com/docker-library/docs/tree/master/varnish

--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:stretch-slim
 
 ENV VARNISH_VERSION 6.3.2-1~stretch
+ENV SIZE 100M
 
 RUN set -ex; \
 	fetchDeps=" \
@@ -26,5 +27,5 @@ WORKDIR /etc/varnish
 COPY docker-varnish-entrypoint /usr/local/bin/
 ENTRYPOINT ["docker-varnish-entrypoint"]
 
-EXPOSE 80
-CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl"]
+EXPOSE 80 8443
+CMD varnishd -F -f /etc/varnish/default.vcl -a http=:80,HTTP -a proxy=:8443,PROXY -s malloc,$SIZE

--- a/populate.sh
+++ b/populate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 declare -A IMAGES
@@ -26,6 +26,7 @@ update_dockerfiles() {
 FROM debian:stretch-slim
 
 ENV VARNISH_VERSION $package
+ENV SIZE 100M
 
 RUN set -ex; \\
 	fetchDeps=" \\
@@ -51,8 +52,8 @@ WORKDIR /etc/varnish
 COPY docker-varnish-entrypoint /usr/local/bin/
 ENTRYPOINT ["docker-varnish-entrypoint"]
 
-EXPOSE 80
-CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl"]
+EXPOSE 80 8443
+CMD varnishd -F -f /etc/varnish/default.vcl -a http=:80,HTTP -a proxy=:8443,PROXY -s malloc,\$SIZE
 EOF
 }
 

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:stretch-slim
 
 ENV VARNISH_VERSION 6.0.6-1~stretch
+ENV SIZE 100M
 
 RUN set -ex; \
 	fetchDeps=" \
@@ -26,5 +27,5 @@ WORKDIR /etc/varnish
 COPY docker-varnish-entrypoint /usr/local/bin/
 ENTRYPOINT ["docker-varnish-entrypoint"]
 
-EXPOSE 80
-CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl"]
+EXPOSE 80 8443
+CMD varnishd -F -f /etc/varnish/default.vcl -a http=:80,HTTP -a proxy=:8443,PROXY -s malloc,$SIZE


### PR DESCRIPTION
- I exposed both port `80` and port `8443`
- I added 2 listening interfaces in the `CMD` command that runs `varnishd` to support both HTTP & PROXY
- I added a `SIZE` environment variable
- I added a `-s malloc,$SIZE` argument to `CMD`
- I had to replace the *array syntax* of the `CMD` and replace it with a string to make sure the `$SIZE` environment variable can be parsed
- I modified the `README.md` and added a *Running* section that contains the information above