### PR TITLE
Update to fix VSV00007

### DIFF
--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV VARNISH_VERSION 6.6.0-1~buster
+ENV VARNISH_VERSION 6.6.1-1~buster
 ENV VARNISH_SIZE 100M
 
 RUN set -ex; \

--- a/populate.sh
+++ b/populate.sh
@@ -9,16 +9,16 @@ CONFIG='
 		"dist": "buster",
 		"workdir": "stable/debian",
 		"repo": "60lts",
-		"pkg": "6.0.7-1~buster",
-		"tags": "6.0.7-1 6.0.7 stable",
+		"pkg": "6.0.8-1~buster",
+		"tags": "6.0.8-1 6.0.8 stable",
 		"key": "48D81A24CB0456F5D59431D94CFCFD6BA750EDCD"
 	},
 	"6.6": {
 		"dist": "buster",
 		"workdir": "fresh/debian",
 		"repo": "66",
-		"pkg": "6.6.0-1~buster",
-		"tags": "6.6.0-1 6.6.0 6 latest fresh",
+		"pkg": "6.6.1-1~buster",
+		"tags": "6.6.1-1 6.6.1 6 latest fresh",
 		"key": "A0378A38E4EACA3660789E570BAC19E3F6C90CD5"
 	}
 }'

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ENV VARNISH_VERSION 6.0.7-1~buster
+ENV VARNISH_VERSION 6.0.8-1~buster
 ENV VARNISH_SIZE 100M
 
 RUN set -ex; \


### PR DESCRIPTION
This updates to the 6.0.8 and 6.6.1 versions of Varnish (released 2021-07-13), addressing the VSV00007 HTTP/2 request smuggling vulnerability.

More information here: https://varnish-cache.org/security/VSV00007.html