### PR TITLE
Allow communication with the Varnish control terminal.

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -30,5 +30,5 @@ WORKDIR /etc/varnish
 COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
-EXPOSE 80 8443
+EXPOSE 80 6082 8443
 CMD []

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -30,5 +30,5 @@ WORKDIR /etc/varnish
 COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
-EXPOSE 80 8443
+EXPOSE 80 6082 8443
 CMD []

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ When running the Varnish image, a `varnishd` process will be started that listen
 
 * port `80` for *plain HTTP*
 * port `8443` for the *PROXY protocol*
+* port `6082` for the *control terminal*
 
 > See [TLS section](#tls) for more information about the primary *PROXY protocol* use case.
 

--- a/fresh/alpine/Dockerfile
+++ b/fresh/alpine/Dockerfile
@@ -30,5 +30,5 @@ WORKDIR /etc/varnish
 COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
-EXPOSE 80 8443
+EXPOSE 80 6082 8443
 CMD []

--- a/fresh/alpine/scripts/docker-varnish-entrypoint
+++ b/fresh/alpine/scripts/docker-varnish-entrypoint
@@ -12,6 +12,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	    -a proxy=:8443,PROXY \
 	    -p feature=+http2 \
 	    -s malloc,$VARNISH_SIZE \
+	    -T :6082 \
 	    "$@"
 fi
 

--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -30,5 +30,5 @@ WORKDIR /etc/varnish
 COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
-EXPOSE 80 8443
+EXPOSE 80 6082 8443
 CMD []

--- a/fresh/debian/scripts/docker-varnish-entrypoint
+++ b/fresh/debian/scripts/docker-varnish-entrypoint
@@ -12,6 +12,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	    -a proxy=:8443,PROXY \
 	    -p feature=+http2 \
 	    -s malloc,$VARNISH_SIZE \
+	    -T :6082 \
 	    "$@"
 fi
 

--- a/scripts/docker-varnish-entrypoint
+++ b/scripts/docker-varnish-entrypoint
@@ -12,6 +12,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	    -a proxy=:8443,PROXY \
 	    -p feature=+http2 \
 	    -s malloc,$VARNISH_SIZE \
+	    -T :6082 \
 	    "$@"
 fi
 

--- a/stable/debian/scripts/docker-varnish-entrypoint
+++ b/stable/debian/scripts/docker-varnish-entrypoint
@@ -12,6 +12,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	    -a proxy=:8443,PROXY \
 	    -p feature=+http2 \
 	    -s malloc,$VARNISH_SIZE \
+	    -T :6082 \
 	    "$@"
 fi
 


### PR DESCRIPTION
Now ... I can't say that I've tested this yet but I can tonight after work.

I was wondering about putting a link to https://varnish-cache.org/docs/6.0/users-guide/run_cli.html in the README as well?

Then again, perhaps this should be optional given the security implications of exposing it?