### PR TITLE
Update versions to address VSV00008 vulnerability

### DIFF
--- a/fresh/alpine/Dockerfile
+++ b/fresh/alpine/Dockerfile
@@ -9,9 +9,9 @@ RUN set -e;\
     cd pkg-varnish-cache/alpine; \
     git checkout d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129; \
     sed -i APKBUILD \
-        -e "s/pkgver=@VERSION@/pkgver=7.0.1/" \
-	-e 's@^source=.*@source="http://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
-	-e "s/^sha512sums=.*/sha512sums=\"7541d50b03a113f0a13660d459cc4c2eb45d57fb19380ab56a5413a4e5d702f9c0856585f09aeea6084a239ad8c69017af3805a864540b4697e0eac29f00b408  varnish-\$pkgver.tgz\"/"; \
+        -e "s/pkgver=@VERSION@/pkgver=7.0.2/" \
+	-e 's@^source=.*@source="https://varnish-cache.org/downloads/varnish-$pkgver.tgz"@' \
+	-e "s/^sha512sums=.*/sha512sums=\"5eb08345c95152639266b7ad241185188477f8fd04e88e4dfda1579719a1a413790a0616f25d70994f6d3b8f7640ea80926ece7c547555dad856fd9f6960c9a3  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \
     addgroup builder abuild; \

--- a/fresh/alpine/Dockerfile.tmpl
+++ b/fresh/alpine/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN set -e;\
     git checkout @PKG_COMMIT@; \
     sed -i APKBUILD \
         -e "s/pkgver=@VERSION@/pkgver=@VARNISH_VERSION@/" \
-	-e 's@^source=.*@source="https://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
+	-e 's@^source=.*@source="https://varnish-cache.org/downloads/varnish-$pkgver.tgz"@' \
 	-e "s/^sha512sums=.*/sha512sums=\"@DIST_SHA512@  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \

--- a/fresh/alpine/Dockerfile.tmpl
+++ b/fresh/alpine/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN set -e;\
     git checkout @PKG_COMMIT@; \
     sed -i APKBUILD \
         -e "s/pkgver=@VERSION@/pkgver=@VARNISH_VERSION@/" \
-	-e 's@^source=.*@source="http://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
+	-e 's@^source=.*@source="https://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
 	-e "s/^sha512sums=.*/sha512sums=\"@DIST_SHA512@  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \

--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -14,10 +14,10 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-7.0.1.tgz -o $tmpdir/orig.tgz; \
-    echo "7541d50b03a113f0a13660d459cc4c2eb45d57fb19380ab56a5413a4e5d702f9c0856585f09aeea6084a239ad8c69017af3805a864540b4697e0eac29f00b408  $tmpdir/orig.tgz" | sha512sum -c -; \
+    curl -f https://varnish-cache.org/downloads/varnish-7.0.2.tgz -o $tmpdir/orig.tgz; \
+    echo "5eb08345c95152639266b7ad241185188477f8fd04e88e4dfda1579719a1a413790a0616f25d70994f6d3b8f7640ea80926ece7c547555dad856fd9f6960c9a3  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
-    sed -i -e "s|@VERSION@|7.0.1|"  "debian/changelog"; \
+    sed -i -e "s|@VERSION@|7.0.2|"  "debian/changelog"; \
     mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --yes" debian/control; \
     sed -i '' debian/varnish*; \
     dpkg-buildpackage -us -uc -j"$(nproc)"; \

--- a/fresh/debian/Dockerfile.tmpl
+++ b/fresh/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \

--- a/fresh/debian/Dockerfile.tmpl
+++ b/fresh/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f https://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \

--- a/next/alpine/Dockerfile
+++ b/next/alpine/Dockerfile
@@ -9,9 +9,9 @@ RUN set -e;\
     cd pkg-varnish-cache/alpine; \
     git checkout d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129; \
     sed -i APKBUILD \
-        -e "s/pkgver=@VERSION@/pkgver=7.0.1/" \
-	-e 's@^source=.*@source="http://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
-	-e "s/^sha512sums=.*/sha512sums=\"7541d50b03a113f0a13660d459cc4c2eb45d57fb19380ab56a5413a4e5d702f9c0856585f09aeea6084a239ad8c69017af3805a864540b4697e0eac29f00b408  varnish-\$pkgver.tgz\"/"; \
+        -e "s/pkgver=@VERSION@/pkgver=7.0.2/" \
+	-e 's@^source=.*@source="https://varnish-cache.org/downloads/varnish-$pkgver.tgz"@' \
+	-e "s/^sha512sums=.*/sha512sums=\"5eb08345c95152639266b7ad241185188477f8fd04e88e4dfda1579719a1a413790a0616f25d70994f6d3b8f7640ea80926ece7c547555dad856fd9f6960c9a3  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \
     addgroup builder abuild; \

--- a/next/alpine/Dockerfile.tmpl
+++ b/next/alpine/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN set -e;\
     git checkout @PKG_COMMIT@; \
     sed -i APKBUILD \
         -e "s/pkgver=@VERSION@/pkgver=@VARNISH_VERSION@/" \
-	-e 's@^source=.*@source="https://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
+	-e 's@^source=.*@source="https://varnish-cache.org/downloads/varnish-$pkgver.tgz"@' \
 	-e "s/^sha512sums=.*/sha512sums=\"@DIST_SHA512@  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \

--- a/next/alpine/Dockerfile.tmpl
+++ b/next/alpine/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN set -e;\
     git checkout @PKG_COMMIT@; \
     sed -i APKBUILD \
         -e "s/pkgver=@VERSION@/pkgver=@VARNISH_VERSION@/" \
-	-e 's@^source=.*@source="http://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
+	-e 's@^source=.*@source="https://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
 	-e "s/^sha512sums=.*/sha512sums=\"@DIST_SHA512@  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \

--- a/next/debian/Dockerfile
+++ b/next/debian/Dockerfile
@@ -14,10 +14,10 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-7.0.1.tgz -o $tmpdir/orig.tgz; \
-    echo "7541d50b03a113f0a13660d459cc4c2eb45d57fb19380ab56a5413a4e5d702f9c0856585f09aeea6084a239ad8c69017af3805a864540b4697e0eac29f00b408  $tmpdir/orig.tgz" | sha512sum -c -; \
+    curl -f https://varnish-cache.org/downloads/varnish-7.0.2.tgz -o $tmpdir/orig.tgz; \
+    echo "5eb08345c95152639266b7ad241185188477f8fd04e88e4dfda1579719a1a413790a0616f25d70994f6d3b8f7640ea80926ece7c547555dad856fd9f6960c9a3  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
-    sed -i -e "s|@VERSION@|7.0.1|"  "debian/changelog"; \
+    sed -i -e "s|@VERSION@|7.0.2|"  "debian/changelog"; \
     mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --yes" debian/control; \
     sed -i '' debian/varnish*; \
     dpkg-buildpackage -us -uc -j"$(nproc)"; \

--- a/next/debian/Dockerfile.tmpl
+++ b/next/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \

--- a/next/debian/Dockerfile.tmpl
+++ b/next/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f https://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \

--- a/old/alpine/Dockerfile
+++ b/old/alpine/Dockerfile
@@ -9,9 +9,9 @@ RUN set -e;\
     cd pkg-varnish-cache/alpine; \
     git checkout d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129; \
     sed -i APKBUILD \
-        -e "s/pkgver=@VERSION@/pkgver=6.6.1/" \
-	-e 's@^source=.*@source="http://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
-	-e "s/^sha512sums=.*/sha512sums=\"af3ee1743af2ede2d3efbb73e5aa9b42c7bbd5f86163ec338c8afd1989c3e51ff3e1b40bed6b72224b5d339a74f22d6e5f3c3faf2fedee8ab4715307ed5d871b  varnish-\$pkgver.tgz\"/"; \
+        -e "s/pkgver=@VERSION@/pkgver=6.6.2/" \
+	-e 's@^source=.*@source="https://varnish-cache.org/downloads/varnish-$pkgver.tgz"@' \
+	-e "s/^sha512sums=.*/sha512sums=\"8fa163678e2e454fcc959ba24f349de00e6c00357df55f37f12f0d3acbcb2799b2f376385cef2d40c14a4cc44a5eea1b5a3fbf6245961611d4fc3ea30699035d  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \
     addgroup builder abuild; \

--- a/old/alpine/Dockerfile.tmpl
+++ b/old/alpine/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN set -e;\
     git checkout @PKG_COMMIT@; \
     sed -i APKBUILD \
         -e "s/pkgver=@VERSION@/pkgver=@VARNISH_VERSION@/" \
-	-e 's@^source=.*@source="https://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
+	-e 's@^source=.*@source="https://varnish-cache.org/downloads/varnish-$pkgver.tgz"@' \
 	-e "s/^sha512sums=.*/sha512sums=\"@DIST_SHA512@  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \

--- a/old/alpine/Dockerfile.tmpl
+++ b/old/alpine/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN set -e;\
     git checkout @PKG_COMMIT@; \
     sed -i APKBUILD \
         -e "s/pkgver=@VERSION@/pkgver=@VARNISH_VERSION@/" \
-	-e 's@^source=.*@source="http://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
+	-e 's@^source=.*@source="https://varnish-cache.org/_downloads/varnish-$pkgver.tgz"@' \
 	-e "s/^sha512sums=.*/sha512sums=\"@DIST_SHA512@  varnish-\$pkgver.tgz\"/"; \
     adduser -D builder; \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers; \

--- a/old/debian/Dockerfile
+++ b/old/debian/Dockerfile
@@ -14,10 +14,10 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-6.6.1.tgz -o $tmpdir/orig.tgz; \
-    echo "af3ee1743af2ede2d3efbb73e5aa9b42c7bbd5f86163ec338c8afd1989c3e51ff3e1b40bed6b72224b5d339a74f22d6e5f3c3faf2fedee8ab4715307ed5d871b  $tmpdir/orig.tgz" | sha512sum -c -; \
+    curl -f https://varnish-cache.org/downloads/varnish-6.6.2.tgz -o $tmpdir/orig.tgz; \
+    echo "8fa163678e2e454fcc959ba24f349de00e6c00357df55f37f12f0d3acbcb2799b2f376385cef2d40c14a4cc44a5eea1b5a3fbf6245961611d4fc3ea30699035d  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
-    sed -i -e "s|@VERSION@|6.6.1|"  "debian/changelog"; \
+    sed -i -e "s|@VERSION@|6.6.2|"  "debian/changelog"; \
     mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --yes" debian/control; \
     sed -i '' debian/varnish*; \
     dpkg-buildpackage -us -uc -j"$(nproc)"; \

--- a/old/debian/Dockerfile.tmpl
+++ b/old/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \

--- a/old/debian/Dockerfile.tmpl
+++ b/old/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f https://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \

--- a/populate.sh
+++ b/populate.sh
@@ -7,31 +7,31 @@ CONFIG='
 {
 	"stable": {
 		"debian": "bullseye",
-		"version": "6.0.8",
+		"version": "6.0.10",
 		"tags": "6.0",
 		"pkg-commit": "10da6a585eb7d8defe9d273a51df5b133500eb6b",
-		"dist-sha512": "73ed2f465ba3b11680b20a70633fc78da9b3eac68395f927b7ff02f4106b6cc92a2b395db2813a0605da2771530e5c4fc594eaf5a9a32bf2e42181b6dd90cf3f"
+		"dist-sha512": "b89ac4465aacde2fde963642727d20d7d33d04f89c0764c43d59fe13e70fe729079fef44da28cc0090fa153ec584a0fe9723fd2ce976e8e9021410a5f73eadd2"
 	},
        "old": {
                "debian": "bullseye",
-               "version": "6.6.1",
+               "version": "6.6.2",
                "tags": "6.6",
                "pkg-commit": "d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129",
-               "dist-sha512": "af3ee1743af2ede2d3efbb73e5aa9b42c7bbd5f86163ec338c8afd1989c3e51ff3e1b40bed6b72224b5d339a74f22d6e5f3c3faf2fedee8ab4715307ed5d871b"
+               "dist-sha512": "8fa163678e2e454fcc959ba24f349de00e6c00357df55f37f12f0d3acbcb2799b2f376385cef2d40c14a4cc44a5eea1b5a3fbf6245961611d4fc3ea30699035d"
        },
 	"fresh": {
 		"debian": "bullseye",
-		"version": "7.0.1",
+		"version": "7.0.2",
 		"tags": "7.0 latest",
 		"pkg-commit": "d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129",
-		"dist-sha512": "7541d50b03a113f0a13660d459cc4c2eb45d57fb19380ab56a5413a4e5d702f9c0856585f09aeea6084a239ad8c69017af3805a864540b4697e0eac29f00b408"
+		"dist-sha512": "5eb08345c95152639266b7ad241185188477f8fd04e88e4dfda1579719a1a413790a0616f25d70994f6d3b8f7640ea80926ece7c547555dad856fd9f6960c9a3"
 	},
 	"next": {
 		"debian": "bullseye",
-		"version": "7.0.1",
+		"version": "7.0.2",
 		"tags": "7.0 latest",
 		"pkg-commit": "d3e6a3fad7d4c2ac781ada92dcc246e7eef9d129",
-		"dist-sha512": "7541d50b03a113f0a13660d459cc4c2eb45d57fb19380ab56a5413a4e5d702f9c0856585f09aeea6084a239ad8c69017af3805a864540b4697e0eac29f00b408"
+		"dist-sha512": "5eb08345c95152639266b7ad241185188477f8fd04e88e4dfda1579719a1a413790a0616f25d70994f6d3b8f7640ea80926ece7c547555dad856fd9f6960c9a3"
 	}
 }'
 

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -14,10 +14,10 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout 10da6a585eb7d8defe9d273a51df5b133500eb6b; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-6.0.8.tgz -o $tmpdir/orig.tgz; \
-    echo "73ed2f465ba3b11680b20a70633fc78da9b3eac68395f927b7ff02f4106b6cc92a2b395db2813a0605da2771530e5c4fc594eaf5a9a32bf2e42181b6dd90cf3f  $tmpdir/orig.tgz" | sha512sum -c -; \
+    curl -f http://varnish-cache.org/_downloads/varnish-6.0.10.tgz -o $tmpdir/orig.tgz; \
+    echo "b89ac4465aacde2fde963642727d20d7d33d04f89c0764c43d59fe13e70fe729079fef44da28cc0090fa153ec584a0fe9723fd2ce976e8e9021410a5f73eadd2  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
-    sed -i -e "s|@VERSION@|6.0.8|"  "debian/changelog"; \
+    sed -i -e "s|@VERSION@|6.0.10|"  "debian/changelog"; \
     mk-build-deps --install --tool="apt-get -o Debug::pkgProblemResolver=yes --yes" debian/control; \
     sed -i '' debian/varnish*; \
     dpkg-buildpackage -us -uc -j"$(nproc)"; \


### PR DESCRIPTION
This updates to the 6.0.10, 6.6.2, and 7.0.2 versions of Varnish (released 2022-01-25), addressing the VSV00008 HTTP/1 Request Smuggling Vulnerability. More information here: https://varnish-cache.org/security/VSV00008.html

A couple other things to note:

* This PR also updates the varnish-cache.org tarball URLs in template files to use HTTPS instead of HTTP. If there's a technical reason behind using HTTP, just let me know and I'll drop the commit, re-run `populate.sh`, and update this branch.
* Similarly, this updates varnish-cache.org tarball URLs in template files to use the `/downloads/` path (e.g., https://varnish-cache.org/downloads/varnish-7.0.2.tgz), as currently used on the Varnish website (e.g., the tarball link on the [7.0.2 release page](https://varnish-cache.org/releases/rel7.0.2.html)). varnish-cache.org previously used URLs with a `/_downloads/` path (e.g., https://varnish-cache.org/_downloads/varnish-7.0.2.tgz) but this changed to `/downloads/` sometime in the past couple months. The `/_downloads/` URLs continue to resolve (200) but this could break in the future, so it's probably best to update these URLs to align with the links on varnish-cache.org.