### PR TITLE
Update stable tarball URL in Debian template

### DIFF
--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout 10da6a585eb7d8defe9d273a51df5b133500eb6b; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-6.0.10.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/downloads/varnish-6.0.10.tgz -o $tmpdir/orig.tgz; \
     echo "b89ac4465aacde2fde963642727d20d7d33d04f89c0764c43d59fe13e70fe729079fef44da28cc0090fa153ec584a0fe9723fd2ce976e8e9021410a5f73eadd2  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|6.0.10|"  "debian/changelog"; \

--- a/stable/debian/Dockerfile.tmpl
+++ b/stable/debian/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN set -e; \
     cd pkg-varnish-cache; \
     git checkout @PKG_COMMIT@; \
     rm -rf .git; \
-    curl -f http://varnish-cache.org/_downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
+    curl -f https://varnish-cache.org/downloads/varnish-@VARNISH_VERSION@.tgz -o $tmpdir/orig.tgz; \
     echo "@DIST_SHA512@  $tmpdir/orig.tgz" | sha512sum -c -; \
     tar xavf $tmpdir/orig.tgz --strip 1; \
     sed -i -e "s|@VERSION@|@VARNISH_VERSION@|"  "debian/changelog"; \


### PR DESCRIPTION
This updates the stable tarball URL in the Debian template to incorporate the changes in #46 (i.e., using HTTPS and switching to the current `/downloads/` path). Unfortunately, I had overlooked this template when modifying the others and these changes were omitted from the previous commits.

This isn't a breaking change at the moment, so it's okay if this isn't shipped out with the version updates. However, if this PR is merged before the related docker-library/official-images PR (docker-library/official-images#11744), I'll update that branch to reflect the change.