### PR TITLE
Add getdns to the build environment for vmod_dynamic on Debian

### DIFF
--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -14,12 +14,12 @@ ENV  VMOD_DEPS="automake curl gcc libtool make pkg-config python3-sphinx"
 ENV VARNISH_SIZE 100M
 
 RUN set -e; \
-    BASE_PKGS="curl dpkg-dev debhelper devscripts equivs git pkg-config apt-utils fakeroot sbuild"; \
+    BASE_PKGS="curl dpkg-dev debhelper devscripts equivs git pkg-config apt-utils fakeroot sbuild libgetdns-dev"; \
     export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     mkdir -p /work/varnish /pkgs; \
     apt-get update; \
-    apt-get install -y $BASE_PKGS; \
+    apt-get install -y $BASE_PKGS libgetdns10; \
     # varnish
     cd /work/varnish; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \

--- a/fresh/debian/Dockerfile.tmpl
+++ b/fresh/debian/Dockerfile.tmpl
@@ -14,12 +14,12 @@ ENV  VMOD_DEPS="automake curl gcc libtool make pkg-config python3-sphinx"
 ENV VARNISH_SIZE 100M
 
 RUN set -e; \
-    BASE_PKGS="curl dpkg-dev debhelper devscripts equivs git pkg-config apt-utils fakeroot sbuild"; \
+    BASE_PKGS="curl dpkg-dev debhelper devscripts equivs git pkg-config apt-utils fakeroot sbuild libgetdns-dev"; \
     export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     mkdir -p /work/varnish /pkgs; \
     apt-get update; \
-    apt-get install -y $BASE_PKGS; \
+    apt-get install -y $BASE_PKGS libgetdns10; \
     # varnish
     cd /work/varnish; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \


### PR DESCRIPTION
Without getdns vmod_dynamic provides less control and reliability over DNS lookups and caching issues

getdns is not packaged for Alpine at this time