### PR TITLE
Exposing port 6082 for potential CLI support

### DIFF
--- a/fresh/alpine/Dockerfile
+++ b/fresh/alpine/Dockerfile
@@ -67,5 +67,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/fresh/alpine/Dockerfile.tmpl
+++ b/fresh/alpine/Dockerfile.tmpl
@@ -67,5 +67,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -64,5 +64,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/fresh/debian/Dockerfile.tmpl
+++ b/fresh/debian/Dockerfile.tmpl
@@ -64,5 +64,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/old/alpine/Dockerfile
+++ b/old/alpine/Dockerfile
@@ -60,5 +60,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/old/alpine/Dockerfile.tmpl
+++ b/old/alpine/Dockerfile.tmpl
@@ -60,5 +60,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/old/debian/Dockerfile
+++ b/old/debian/Dockerfile
@@ -58,5 +58,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/old/debian/Dockerfile.tmpl
+++ b/old/debian/Dockerfile.tmpl
@@ -58,5 +58,5 @@ COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
 USER varnish
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -32,5 +32,5 @@ WORKDIR /etc/varnish
 COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []

--- a/stable/debian/Dockerfile.tmpl
+++ b/stable/debian/Dockerfile.tmpl
@@ -32,5 +32,5 @@ WORKDIR /etc/varnish
 COPY scripts/ /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/docker-varnish-entrypoint"]
 
-EXPOSE 80 8443
+EXPOSE 80 8443 6082
 CMD []


### PR DESCRIPTION
Hey @gquintard,

I see some use cases and a StackOverflow question where people would need access to the Varnish CLI. But since port `6082` is not exposed, it's probably not possible for users to extend the `varnishd` runtime parameters using the [`$@` syntax](https://github.com/varnish/docker-varnish/blob/master/fresh/debian/scripts/docker-varnish-entrypoint#L15) to remotely access the Varnish CLI

Does it make sense to just add port `6082` to the `EXPOSE` directive and expect the users to attach the `-T` & `-S` parameters in their Docker run command if they want to use the Varnish CLI?