### PR TITLE
Allow VARNISH_VCL_FILE env var to change the varnish filename.

### DIFF
--- a/fresh/alpine/scripts/docker-varnish-entrypoint
+++ b/fresh/alpine/scripts/docker-varnish-entrypoint
@@ -7,7 +7,7 @@ set -e
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
     set -- varnishd \
 	    -F \
-	    -f /etc/varnish/default.vcl \
+	    -f ${VARNISH_VCL_FILE:-/etc/varnish/default.vcl} \
 	    -a http=:${VARNISH_HTTP_PORT:-80},HTTP \
 	    -a proxy=:${VARNISH_PROXY_PORT:-8443},PROXY \
 	    -p feature=+http2 \

--- a/fresh/debian/scripts/docker-varnish-entrypoint
+++ b/fresh/debian/scripts/docker-varnish-entrypoint
@@ -7,7 +7,7 @@ set -e
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
     set -- varnishd \
 	    -F \
-	    -f /etc/varnish/default.vcl \
+	    -f ${VARNISH_VCL_FILE:-/etc/varnish/default.vcl} \
 	    -a http=:${VARNISH_HTTP_PORT:-80},HTTP \
 	    -a proxy=:${VARNISH_PROXY_PORT:-8443},PROXY \
 	    -p feature=+http2 \

--- a/old/alpine/scripts/docker-varnish-entrypoint
+++ b/old/alpine/scripts/docker-varnish-entrypoint
@@ -7,7 +7,7 @@ set -e
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
     set -- varnishd \
 	    -F \
-	    -f /etc/varnish/default.vcl \
+	    -f ${VARNISH_VCL_FILE:-/etc/varnish/default.vcl} \
 	    -a http=:${VARNISH_HTTP_PORT:-80},HTTP \
 	    -a proxy=:${VARNISH_PROXY_PORT:-8443},PROXY \
 	    -p feature=+http2 \

--- a/old/debian/scripts/docker-varnish-entrypoint
+++ b/old/debian/scripts/docker-varnish-entrypoint
@@ -7,7 +7,7 @@ set -e
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
     set -- varnishd \
 	    -F \
-	    -f /etc/varnish/default.vcl \
+	    -f ${VARNISH_VCL_FILE:-/etc/varnish/default.vcl} \
 	    -a http=:${VARNISH_HTTP_PORT:-80},HTTP \
 	    -a proxy=:${VARNISH_PROXY_PORT:-8443},PROXY \
 	    -p feature=+http2 \

--- a/stable/debian/scripts/docker-varnish-entrypoint
+++ b/stable/debian/scripts/docker-varnish-entrypoint
@@ -7,7 +7,7 @@ set -e
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
     set -- varnishd \
 	    -F \
-	    -f /etc/varnish/default.vcl \
+	    -f ${VARNISH_VCL_FILE:-/etc/varnish/default.vcl} \
 	    -a http=:${VARNISH_HTTP_PORT:-80},HTTP \
 	    -a proxy=:${VARNISH_PROXY_PORT:-8443},PROXY \
 	    -p feature=+http2 \


### PR DESCRIPTION
This is incredibly useful for us and adding it here would avoid us having to overwrite the entry point script with a custom script in our builds.

The use case is if you have say 'default.vcl' 'maintenance.vcl', 'service-x-is-down-right-now.vcl'.. you can quickly switch them by editing the pod definition. We don't care that much about cache preservation across restarts. We can bake in our static configurations at build time and switch them, this better aligns with declarative system practices than altering the VCL using runtime commands. 

I don't know where the documentation is stored but we'd obv need to add this variable to that.