### PR TITLE
Upgrade Alpine base to 3.21

### DIFF
--- a/fresh/alpine/Dockerfile
+++ b/fresh/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.21
 
 ARG  PKG_COMMIT=7d90347be31891b338dededb318594cebb668ba7
 ARG  VARNISH_VERSION=7.7.0
@@ -15,7 +15,7 @@ ENV VARNISH_SIZE=100M
 ENV VSM_NOPID=1
 
 RUN set -ex;\
-    BASE_PKGS="tar alpine-sdk sudo py3-docutils python3 autoconf automake libtool"; \
+    BASE_PKGS="tar alpine-sdk curl sudo py3-docutils python3 autoconf automake libtool"; \
     apk add --virtual varnish-build-deps -q --no-progress --update $BASE_PKGS; \
     \
     # create users and groups with fixed IDs

--- a/old/alpine/Dockerfile
+++ b/old/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.21
 
 ARG  PKG_COMMIT=7d90347be31891b338dededb318594cebb668ba7
 ARG  VARNISH_VERSION=7.6.1
@@ -15,7 +15,7 @@ ENV VARNISH_SIZE=100M
 ENV VSM_NOPID=1
 
 RUN set -ex;\
-    BASE_PKGS="tar alpine-sdk sudo py3-docutils python3 autoconf automake libtool"; \
+    BASE_PKGS="tar alpine-sdk curl sudo py3-docutils python3 autoconf automake libtool"; \
     apk add --virtual varnish-build-deps -q --no-progress --update $BASE_PKGS; \
     \
     # create users and groups with fixed IDs


### PR DESCRIPTION
Alpine 3.19 is ~16 months old, while 3.21 was released ~4 months ago.

Changes to packages require the explicit inclusion of `curl` in `BASE_PKGS`. Specifically, `alpine-sdk` includes `abuild`; in Alpine 3.19 this depends on `curl`, while in 3.20 & 3.21 it does not. As a result, `curl` does not get automatically installed as an indirect dependency.

See: https://pkgs.alpinelinux.org/package/v3.19/main/x86_64/abuild
See: https://pkgs.alpinelinux.org/package/v3.20/main/x86_64/abuild