### PR TITLE
Update Dockerfile for Debian 13 Trixie 

### DIFF
--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:trixie-slim
 
-ARG  PKG_COMMIT=7d90347be31891b338dededb318594cebb668ba7
+ARG  PKG_COMMIT=1f0d212dc45065f38bd80ac57fe22773a20a0595
 ARG  VARNISH_VERSION=7.7.2
 ARG  DIST_SHA512=7a063fa26c01abef3f1c04adaf1a07eb8ebb3d7631f4c797fb4082c75d9133a1e830c5fbbf7f36cc921d502dcfbb36e93ef1cd46e65cf1885efcb740f86da8ac
 ARG  VARNISH_MODULES_VERSION=0.26.0
@@ -32,8 +32,6 @@ RUN set -ex; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \
     cd pkg-varnish-cache; \
     git checkout $PKG_COMMIT; \
-    # temporary pending https://github.com/varnishcache/pkg-varnish-cache/pull/182
-    sed -i '/libpcre3-dev,/d' debian/control; \
     rm -rf .git; \
     curl -f https://varnish-cache.org/downloads/varnish-$VARNISH_VERSION.tgz -o $tmpdir/orig.tgz; \
     echo "$DIST_SHA512  $tmpdir/orig.tgz" | sha512sum -c -; \

--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG  PKG_COMMIT=7d90347be31891b338dededb318594cebb668ba7
 ARG  VARNISH_VERSION=7.7.2
@@ -20,7 +20,7 @@ RUN set -ex; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     mkdir -p /work/varnish /pkgs; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $BASE_PKGS libgetdns10 netbase; \
+    apt-get install -y --no-install-recommends $BASE_PKGS adduser libgetdns10 netbase; \
     \
     # create users and groups with fixed IDs
     adduser --uid 1000 --quiet --system --no-create-home --home /nonexistent --group varnish; \
@@ -32,6 +32,7 @@ RUN set -ex; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \
     cd pkg-varnish-cache; \
     git checkout $PKG_COMMIT; \
+    sed -i '/libpcre3-dev,/d' debian/control; \   # temporary pending https://github.com/varnishcache/pkg-varnish-cache/pull/182
     rm -rf .git; \
     curl -f https://varnish-cache.org/downloads/varnish-$VARNISH_VERSION.tgz -o $tmpdir/orig.tgz; \
     echo "$DIST_SHA512  $tmpdir/orig.tgz" | sha512sum -c -; \
@@ -55,7 +56,8 @@ RUN set -ex; \
     # vmod-dynamic
     install-vmod https://github.com/nigoroll/libvmod-dynamic/archive/$VMOD_DYNAMIC_COMMIT.tar.gz $VMOD_DYNAMIC_SHA512SUM; \
     \
-    # clean up
+    # clean up and ensure varnish package is not removed.
+    apt-mark hold varnish; \
     apt-get -y purge --auto-remove varnish-build-deps $BASE_PKGS varnish-dev; \
     rm -rf /var/lib/apt/lists/* /work/ /usr/lib/varnish/vmods/libvmod_*.la; \
     chown varnish /var/lib/varnish; \

--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -32,7 +32,8 @@ RUN set -ex; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \
     cd pkg-varnish-cache; \
     git checkout $PKG_COMMIT; \
-    sed -i '/libpcre3-dev,/d' debian/control; \   # temporary pending https://github.com/varnishcache/pkg-varnish-cache/pull/182
+    # temporary pending https://github.com/varnishcache/pkg-varnish-cache/pull/182
+    sed -i '/libpcre3-dev,/d' debian/control; \
     rm -rf .git; \
     curl -f https://varnish-cache.org/downloads/varnish-$VARNISH_VERSION.tgz -o $tmpdir/orig.tgz; \
     echo "$DIST_SHA512  $tmpdir/orig.tgz" | sha512sum -c -; \

--- a/old/debian/Dockerfile
+++ b/old/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG  PKG_COMMIT=7d90347be31891b338dededb318594cebb668ba7
 ARG  VARNISH_VERSION=7.6.4
@@ -20,7 +20,7 @@ RUN set -ex; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     mkdir -p /work/varnish /pkgs; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $BASE_PKGS libgetdns10 netbase; \
+    apt-get install -y --no-install-recommends $BASE_PKGS adduser libgetdns10 netbase; \
     \
     # create users and groups with fixed IDs
     adduser --uid 1000 --quiet --system --no-create-home --home /nonexistent --group varnish; \
@@ -32,6 +32,8 @@ RUN set -ex; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \
     cd pkg-varnish-cache; \
     git checkout $PKG_COMMIT; \
+    # temporary pending https://github.com/varnishcache/pkg-varnish-cache/pull/182
+    sed -i '/libpcre3-dev,/d' debian/control; \
     rm -rf .git; \
     curl -f https://varnish-cache.org/downloads/varnish-$VARNISH_VERSION.tgz -o $tmpdir/orig.tgz; \
     echo "$DIST_SHA512  $tmpdir/orig.tgz" | sha512sum -c -; \
@@ -55,7 +57,8 @@ RUN set -ex; \
     # vmod-dynamic
     install-vmod https://github.com/nigoroll/libvmod-dynamic/archive/$VMOD_DYNAMIC_COMMIT.tar.gz $VMOD_DYNAMIC_SHA512SUM; \
     \
-    # clean up
+    # clean up and ensure varnish package is not removed.
+    apt-mark hold varnish; \
     apt-get -y purge --auto-remove varnish-build-deps $BASE_PKGS varnish-dev; \
     rm -rf /var/lib/apt/lists/* /work/ /usr/lib/varnish/vmods/libvmod_*.la; \
     chown varnish /var/lib/varnish; \

--- a/old/debian/Dockerfile
+++ b/old/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:trixie-slim
 
-ARG  PKG_COMMIT=7d90347be31891b338dededb318594cebb668ba7
+ARG  PKG_COMMIT=1f0d212dc45065f38bd80ac57fe22773a20a0595
 ARG  VARNISH_VERSION=7.6.4
 ARG  DIST_SHA512=3af49e766bc9fe3686d859dce5b299b4caec07b18e91079f384f0a947bebed02ae9d9030f4a3f51b5c316e71ca07124ae83fbebcfe905b29ff9a285e6daea887
 ARG  VARNISH_MODULES_VERSION=0.25.0
@@ -32,8 +32,6 @@ RUN set -ex; \
     git clone https://github.com/varnishcache/pkg-varnish-cache.git; \
     cd pkg-varnish-cache; \
     git checkout $PKG_COMMIT; \
-    # temporary pending https://github.com/varnishcache/pkg-varnish-cache/pull/182
-    sed -i '/libpcre3-dev,/d' debian/control; \
     rm -rf .git; \
     curl -f https://varnish-cache.org/downloads/varnish-$VARNISH_VERSION.tgz -o $tmpdir/orig.tgz; \
     echo "$DIST_SHA512  $tmpdir/orig.tgz" | sha512sum -c -; \


### PR DESCRIPTION
Addressing Debian Trixie build for the fresh/ folder.. 
https://github.com/varnish/docker-varnish/issues/87


adduser needs to be explicitly added.
hack out libpcre3-dev pending PR in other project
hold varnish package from possibly being purged unintentionally.