### PR TITLE
Replace `libgetdns10` with `libgetdns10t64`

### DIFF
--- a/fresh/debian/Dockerfile
+++ b/fresh/debian/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     mkdir -p /work/varnish /pkgs; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $BASE_PKGS adduser libgetdns10 netbase; \
+    apt-get install -y --no-install-recommends $BASE_PKGS adduser libgetdns10t64 netbase; \
     \
     # create users and groups with fixed IDs
     adduser --uid 1000 --quiet --system --no-create-home --home /nonexistent --group varnish; \

--- a/old/debian/Dockerfile
+++ b/old/debian/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     mkdir -p /work/varnish /pkgs; \
     apt-get update; \
-    apt-get install -y --no-install-recommends $BASE_PKGS adduser libgetdns10 netbase; \
+    apt-get install -y --no-install-recommends $BASE_PKGS adduser libgetdns10t64 netbase; \
     \
     # create users and groups with fixed IDs
     adduser --uid 1000 --quiet --system --no-create-home --home /nonexistent --group varnish; \


### PR DESCRIPTION
I'm not sure why this is installed explicitly (shouldn't it be pulled in/kept by a build-time dev package?) but in Trixie+ it's been renamed for the time64 transition.

I'm *also* not sure why it only seems to fail to build on arm32v7, but I'm sure there's some funky dependency relationship causing it:

```
Package libgetdns10 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libgetdns10t64

E: Package 'libgetdns10' has no installation candidate
```