### PR TITLE
populate.sh: force sed -E for predictability

### DIFF
--- a/populate.sh
+++ b/populate.sh
@@ -15,12 +15,12 @@ update_library(){
 	done
 
 	if [ "$2" != "debian" ]; then
-		tags=`echo "$tags" | sed -e "s/\( \|$\)/-$2\1/g"`
+		tags=`echo "$tags" | sed -E "s/( |$)/-$2\1/g"`
 	fi
 
 	cat >> library.varnish <<- EOF
 
-		Tags: `echo $tags | sed 's/ \+/, /g'`
+		Tags: `echo $tags | sed -E 's/ +/, /g'`
 		Architectures: amd64, arm64v8
 		Directory: $1/$2
 		GitCommit: `git log -n1 --pretty=oneline $1/$2 | cut -f1 -d" "`


### PR DESCRIPTION
@briiians, can you validate the output of `./populate.sh library` with this branch please? (tags should be comma-separated, and we should have the `-alpine` suffix for the `alpine` images):

```
# this file was generated using https://github.com/varnish/docker-varnish/blob/d97be567afaf4a399a2062052a526d06769fa074/populate.sh
Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
GitRepo: https://github.com/varnish/docker-varnish.git

Tags: fresh, latest, 9.0.3-3, 9.0.3, 9.0, 9
Architectures: amd64, arm64v8
Directory: fresh/debian
GitCommit: 5ba9f9ce6a65fc569f0fbfc6f06b57c66b620875
GitFetch: refs/heads/main

Tags: old, 8.0.2-1, 8.0.2, 8.0, 8
Architectures: amd64, arm64v8
Directory: old/debian
GitCommit: 40cfe05d7eba91c1d6588f9bb40ed64ee84312fe
GitFetch: refs/heads/main

Tags: old-alpine, 8.0.2-alpine, 8.0-alpine, 8-alpine
Architectures: amd64, arm64v8
Directory: old/alpine
GitCommit: 40cfe05d7eba91c1d6588f9bb40ed64ee84312fe
GitFetch: refs/heads/main

Tags: stable, 6.0.18-1, 6.0.18, 6.0, 6
Architectures: amd64, arm64v8
Directory: stable/debian
GitCommit: c9eabe6cdbfbf5f5c2ee9959f42d926cbcc234c1
GitFetch: refs/heads/main
```